### PR TITLE
Handle missing Celery broker

### DIFF
--- a/core/api/routes/transcribe.py
+++ b/core/api/routes/transcribe.py
@@ -5,6 +5,8 @@ from flask_restx import Namespace, Resource, fields
 from flask_limiter import Limiter
 from loguru import logger
 import os
+import redis
+from kombu.exceptions import OperationalError
 
 from core.services import TranscriptionService, FileService, QueueService
 from core.models import TranscribeRequest, BatchTranscribeRequest
@@ -87,7 +89,11 @@ def create_transcribe_blueprint(limiter):
             
             # Use Celery batch transcription task for better integration with captioning workflow
             logger.info(f"Starting Celery batch transcription for {len(valid_paths)} files")
-            batch_task = batch_transcription.delay(valid_paths)
+            try:
+                batch_task = batch_transcription.delay(valid_paths)
+            except (OperationalError, redis.exceptions.ConnectionError) as e:
+                logger.error(f"Celery broker unavailable: {e}")
+                return jsonify({'error': 'Task queue unavailable'}), 503
             
             # Return response with task ID for tracking
             response_data = {

--- a/core/tasks/__init__.py
+++ b/core/tasks/__init__.py
@@ -17,6 +17,7 @@ Example:
 from celery import Celery
 from core.config import REDIS_URL
 from loguru import logger
+import os
 
 celery_app = Celery(
     "archivist",
@@ -37,6 +38,12 @@ celery_app.conf.update(
     timezone="UTC",
     enable_utc=True,
 )
+
+# Allow running tasks synchronously when a broker isn't available
+if os.getenv("CELERY_TASK_ALWAYS_EAGER", "").lower() == "true":
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_eager_propagates = True
+    logger.warning("Celery configured for eager execution; tasks run synchronously")
 
 logger.info(f"Celery app initialised with broker {REDIS_URL}")
 


### PR DESCRIPTION
## Summary
- gracefully handle failed Celery broker connections in the batch transcription endpoint
- allow running Celery tasks synchronously when `CELERY_TASK_ALWAYS_EAGER` is set

## Testing
- `pytest -q -o addopts=` *(fails: No module named 'loguru', 'requests', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688cff2ba1f0832cbfc53d729099f0b6