### PR TITLE
Add per-file transcribe action in browser

### DIFF
--- a/core/templates/index.html
+++ b/core/templates/index.html
@@ -393,12 +393,18 @@
                             return `
                                 <div class="file-item flex items-center justify-between p-2 hover:bg-gray-700 rounded">
                                     <div class="flex items-center gap-2">
-                                        <input type="checkbox" class="file-checkbox" value="${item.path}" 
+                                        <input type="checkbox" class="file-checkbox" value="${item.path}"
                                                onchange="handleFileSelection('${item.path}', this.checked)">
                                         <span class="text-gray-400">📄</span>
                                         <span class="file-name">${item.name}</span>
                                     </div>
-                                    <span class="text-sm text-gray-400">${formatSize(item.size)}</span>
+                                    <div class="flex items-center gap-2">
+                                        <span class="text-sm text-gray-400">${formatSize(item.size)}</span>
+                                        <button onclick="transcribe('${item.path}')"
+                                                class="bg-blue-600 hover:bg-blue-700 text-white px-2 py-1 rounded text-xs">
+                                            Transcribe
+                                        </button>
+                                    </div>
                                 </div>
                             `;
                         }


### PR DESCRIPTION
## Summary
- Add a "Transcribe" button for each file in the browser to call `transcribe()` with its path

## Testing
- `pytest -o addopts=""` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_e_689106cafa20832cae24c50abf9e64fe